### PR TITLE
Vis feil når man henter data i klienten

### DIFF
--- a/ClientApp/src/app/fetch-data/fetch-data.component.html
+++ b/ClientApp/src/app/fetch-data/fetch-data.component.html
@@ -2,7 +2,7 @@
 
 <p>This component demonstrates fetching data from the server.</p>
 
-<p *ngIf="!forecasts"><em>Loading...</em></p>
+<p *ngIf="!forecasts && errorMessage === null"><em>Loading...</em></p>
 
 <table class='table table-striped' aria-labelledby="tableLabel" *ngIf="forecasts">
   <thead>
@@ -22,3 +22,8 @@
     </tr>
   </tbody>
 </table>
+
+<div *ngIf="errorMessage">
+  <h5>Error while fetching data:</h5>
+  <p>{{errorMessage | json}}</p>
+</div>

--- a/ClientApp/src/app/fetch-data/fetch-data.component.ts
+++ b/ClientApp/src/app/fetch-data/fetch-data.component.ts
@@ -7,11 +7,15 @@ import { HttpClient } from '@angular/common/http';
 })
 export class FetchDataComponent {
   public forecasts: WeatherForecast[];
+  public errorMessage: string;
 
   constructor(http: HttpClient, @Inject('BASE_URL') baseUrl: string) {
-    http.get<WeatherForecast[]>(baseUrl + 'weatherforecast').subscribe(result => {
+    http.get<WeatherForecast[]>(baseUrl + 'api/weatherforecast').subscribe(result => {
       this.forecasts = result;
-    }, error => console.error(error));
+    }, error => {
+      this.errorMessage = error;
+      console.error(error);
+    });
   }
 }
 

--- a/Controllers/WeatherForecastController.cs
+++ b/Controllers/WeatherForecastController.cs
@@ -1,14 +1,13 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 
 namespace dotnet_new_angular.Controllers
 {
     [ApiController]
-    [Route("[controller]")]
+    [Route("api/[controller]")]
     public class WeatherForecastController : ControllerBase
     {
         private static readonly string[] Summaries = new[]

--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ Copy the `appsettings.Template.json` and name it `appsettings.json`.
 You need to have a client that is registered in HelseId's test environment in order to setup this demo.
 The client needs to be configured with a callback URL for localhost that matches the port you are running to app on.
 
-By default the app is set up to run on port 51384 in [Program.cs](https://github.com/folkehelseinstituttet/fhi.helseid.demo/blob/master/Program.cs).
-This is the configuration HelseId needs to setup as a Redirect URI for your app.
+By default this demo app is set up to run on port 51384 in [Program.cs](https://github.com/folkehelseinstituttet/fhi.helseid.demo/blob/master/Program.cs).
+This is the configuration HelseId needs to setup as a Redirect URI for your app:
 
 ```
 https://localhost:51384/signin-callback

--- a/Startup.cs
+++ b/Startup.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using dotnet_new_angular.DataProtection;
 using dotnet_new_angular.HelseId;
@@ -7,8 +6,6 @@ using Fhi.HelseId.Web.ExtensionMethods;
 using Fhi.HelseId.Web.Hpr;
 using Fhi.HelseId.Web.Services;
 using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.DataProtection;
-using Microsoft.AspNetCore.DataProtection.Repositories;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.SpaServices.AngularCli;

--- a/dotnet-new-angular.csproj
+++ b/dotnet-new-angular.csproj
@@ -15,7 +15,7 @@
 
   <ItemGroup>
     <PackageReference Include="Fhi.HelseId" Version="2.0.0-beta.2" />
-    <PackageReference Include="Microsoft.AspNetCore.SpaServices.Extensions" Version="3.1.7" />
+    <PackageReference Include="Microsoft.AspNetCore.SpaServices.Extensions" Version="3.1.9" />
     <PackageReference Include="System.Data.SqlClient" Version="4.8.2" />
   </ItemGroup>
 


### PR DESCRIPTION
## Vise feil
Viser feil i klienten, bare for å gjøre det veldig tydelig dersom noe oppstår:

![bilde](https://user-images.githubusercontent.com/1527808/97447198-993cfb80-192f-11eb-9622-1b9a55f5900b.png)

## Små fikser
- Endre kallet som henter data til å starte med `/api`, siden komponenten legger noen føringer for dette:
https://github.com/folkehelseinstituttet/fhi.helseid/blob/7e67dc39b942d294d407907b323544789a4eec50/Fhi.HelseId/Web/ExtensionMethods/HelseIdExtensions.cs#L54

- Oppdatere `Microsoft.AspNetCore.SpaServices.Extensions`